### PR TITLE
S118012: Update ckeditor-dev version to 4.6.2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,8 @@ pids
 .*rc
 
 bin
+ckeditor-build-config.js
+dist/ckeditor/samples
+sample.html
+skins
+plugins

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ CkEditor build configured for Sombrero UI library and CA Agile Central.
 
 * `npm install`
 * edit `ckeditor-build-config.js`
-* `npm run build`
+* `npm run build` or `npm run build-dev` to build an unminified version.
 
 ## Skin development
 
 * Open `sample.html` in a browser.
 * Modify CSS in `skins/sombrero`.
-* `npm run build` and refresh browser to see changes.
+* Note that default editor content styles are not part of a skin but rather are located in `contents.css`.
+* Rebuild and refresh browser to see changes.

--- a/bin/build
+++ b/bin/build
@@ -1,12 +1,19 @@
 #!/bin/bash
 
+while getopts u option; do
+  case "${option}" in
+    u) UNMINIFIED="--leave-js-unminified";;
+  esac
+done
+
 mkdir -p node_modules/ckeditor-dev/plugins
 cp -R plugins/ node_modules/ckeditor-dev/plugins/. && \
 cp -f ckeditor-build-config.js node_modules/ckeditor-dev/dev/builder/build-config.js && \
 cp -R skins/sombrero node_modules/ckeditor-dev/skins && \
 chmod +x node_modules/ckeditor-dev/dev/builder/build.sh && \
-node_modules/ckeditor-dev/dev/builder/build.sh && \
+node_modules/ckeditor-dev/dev/builder/build.sh standard $UNMINIFIED && \
 rm -rf dist && \
 mkdir dist && \
 cp -R node_modules/ckeditor-dev/dev/builder/release/ckeditor dist/ckeditor && \
+cp contents.css dist/ckeditor/contents.css &&
 cp skins/sombrero/skin.js dist/ckeditor/skins/sombrero

--- a/contents.css
+++ b/contents.css
@@ -1,0 +1,212 @@
+/*
+Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+*/
+
+body
+{
+	/* Font */
+	font-family: sans-serif, Arial, Verdana, "Trebuchet MS";
+	font-size: 12px;
+
+	/* Text color */
+	color: #333;
+
+	/* Remove the background color to make it transparent */
+	background-color: #fff;
+
+	margin: 20px;
+}
+
+.cke_editable
+{
+	font-size: 13px;
+	line-height: 1.6;
+
+	/* Fix for missing scrollbars with RTL texts. (#10488) */
+	word-wrap: break-word;
+}
+
+blockquote
+{
+	font-style: italic;
+	font-family: Georgia, Times, "Times New Roman", serif;
+	padding: 2px 0;
+	border-style: solid;
+	border-color: #ccc;
+	border-width: 0;
+}
+
+.cke_contents_ltr blockquote
+{
+	padding-left: 20px;
+	padding-right: 8px;
+	border-left-width: 5px;
+}
+
+.cke_contents_rtl blockquote
+{
+	padding-left: 8px;
+	padding-right: 20px;
+	border-right-width: 5px;
+}
+
+a
+{
+	color: #0782C1;
+}
+
+ol,ul,dl
+{
+	/* IE7: reset rtl list margin. (#7334) */
+	*margin-right: 0px;
+	/* preserved spaces for list items with text direction other than the list. (#6249,#8049)*/
+	padding: 0 40px;
+}
+
+h1,h2,h3,h4,h5,h6
+{
+	font-weight: normal;
+	line-height: 1.2;
+}
+
+hr
+{
+	border: 0px;
+	border-top: 1px solid #ccc;
+}
+
+img.right
+{
+	border: 1px solid #ccc;
+	float: right;
+	margin-left: 15px;
+	padding: 5px;
+}
+
+img.left
+{
+	border: 1px solid #ccc;
+	float: left;
+	margin-right: 15px;
+	padding: 5px;
+}
+
+pre
+{
+	white-space: pre-wrap; /* CSS 2.1 */
+	word-wrap: break-word; /* IE7 */
+	-moz-tab-size: 4;
+	tab-size: 4;
+}
+
+.marker
+{
+	background-color: Yellow;
+}
+
+span[lang]
+{
+	font-style: italic;
+}
+
+figure
+{
+	text-align: center;
+	border: solid 1px #ccc;
+	border-radius: 2px;
+	background: rgba(0,0,0,0.05);
+	padding: 10px;
+	margin: 10px 20px;
+	display: inline-block;
+}
+
+figure > figcaption
+{
+	text-align: center;
+	display: block; /* For IE8 */
+}
+
+a > img {
+	padding: 1px;
+	margin: 1px;
+	border: none;
+	outline: 1px solid #0782C1;
+}
+
+table, td, th {
+  border-style: solid;
+}
+
+/* Widget Styles */
+.code-featured
+{
+	border: 5px solid red;
+}
+
+.math-featured
+{
+	padding: 20px;
+	box-shadow: 0 0 2px rgba(200, 0, 0, 1);
+	background-color: rgba(255, 0, 0, 0.05);
+	margin: 10px;
+}
+
+.image-clean
+{
+	border: 0;
+	background: none;
+	padding: 0;
+}
+
+.image-clean > figcaption
+{
+	font-size: .9em;
+	text-align: right;
+}
+
+.image-grayscale
+{
+	background-color: white;
+	color: #666;
+}
+
+.image-grayscale img, img.image-grayscale
+{
+	filter: grayscale(100%);
+}
+
+.embed-240p
+{
+	max-width: 426px;
+	max-height: 240px;
+	margin:0 auto;
+}
+
+.embed-360p
+{
+	max-width: 640px;
+	max-height: 360px;
+	margin:0 auto;
+}
+
+.embed-480p
+{
+	max-width: 854px;
+	max-height: 480px;
+	margin:0 auto;
+}
+
+.embed-720p
+{
+	max-width: 1280px;
+	max-height: 720px;
+	margin:0 auto;
+}
+
+.embed-1080p
+{
+	max-width: 1920px;
+	max-height: 1080px;
+	margin:0 auto;
+}

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
   "name": "agile-central-ckeditor",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "ckeditor configured for AgileCentral",
   "author": "CA Technologies",
+  "license": "MPL-1.1",
   "scripts": {
-    "build": "bin/build"
+    "build": "bin/build",
+    "build-dev": "bin/build -u",
+    "pack-ls": "npm pack && tar -tzvf agile-central-ckeditor*.tgz && rm agile-central-ckeditor*.tgz"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/RallySoftware/agile-central-ckeditor.git"
   },
-  "main": "ckeditor/ckeditor.js",
+  "main": "dist/ckeditor/ckeditor.js",
   "devDependencies": {
-    "ckeditor-dev": "4.5.6"
+    "ckeditor-dev": "4.6.2"
   }
 }


### PR DESCRIPTION
#### What does this PR do?

* Update `ckeditor-dev` version to 4.6.2
* Add license to `package.json`
* Adjust `.npmignore` to exclude some unneeded files
* Add `pack-ls` npm script to easily see contents of npm package
* Add `build-dev` npm script to build an unminified version for easier development/debugging
* Modify build to allow customization of editor content styles
* Customize default table border-style
* Bump version

