### PR TITLE
DE32460: Updating to ckEditor 4.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agile-central-ckeditor",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "ckeditor configured for AgileCentral",
   "author": "CA Technologies",
   "license": "MPL-1.1",
@@ -17,7 +17,7 @@
   },
   "main": "dist/ckeditor/ckeditor.js",
   "devDependencies": {
-    "ckeditor-dev": "4.6.2",
+    "ckeditor-dev": "4.7.0",
     "nodemon": "^1.11.0"
   }
 }


### PR DESCRIPTION
Updating to CKEditor 4.7 fixes this issue - https://dev.ckeditor.com/ticket/16825#comment:4 which occurs in AC when a user has focus on a ckeditor then loads a different page. The blur event was calling back to RichTextEditor after the component was already unmounted, thus causing an error.