### PR TITLE
feat(Editor): S174697 - Fix word wrap in text editor - ie11 fix

### DIFF
--- a/contents.css
+++ b/contents.css
@@ -62,7 +62,10 @@ ol,ul,dl
 	*margin-right: 0px;
 	/* preserved spaces for list items with text direction other than the list. (#6249,#8049)*/
 	padding: 0 40px;
-	width: 100%;
+}
+
+.cke_editable ol, .cke_editable ul, .cke_editable dl {
+	word-wrap: normal;
 }
 
 h1,h2,h3,h4,h5,h6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agile-central-ckeditor",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "ckeditor configured for AgileCentral",
   "author": "Rally",
   "license": "MPL-1.1",


### PR DESCRIPTION
Fixes an issue where text begins to wrap unexpectedly when bullet points are nested a certain number of times. This uses a separate approach for preventing wrapping and should fix issues created in IE11 with the previous fix.